### PR TITLE
Fix: Issue#7 Inconsistent Background Scrolling Speed

### DIFF
--- a/mainGame.c
+++ b/mainGame.c
@@ -457,33 +457,42 @@ void Update(void) {
         playerJumpForce += 20 * delta_time;
     }
 
-    int parallaxValue = delta_time * PLAYER_SPEED;
+    // UPDATED: Calculate player movement *before* updating player_X
+    float player_movement = moveLR * delta_time * PLAYER_SPEED; 
+
+    // UPDATED: Update player_X using player_movement
+    player_X += player_movement;
+
+    // UPDATED: Player Position Limiting logic moved here *after* player_X update
+    //int parallaxValue = delta_time * PLAYER_SPEED; // Now use player_movement instead of parallaxValue below
     if (player_X > (float)WINDOW_WIDTH * (rightCam/5)){
-        background_img_src_rect.x += 100 * delta_time;
-        if (background_img_src_rect.x >= background_img_src_rect.w)
-            background_img_src_rect.x = 0;
         player_X = (rightCam/5) * (float)WINDOW_WIDTH;
         distanceTravelledByPlayerFromSpawn += delta_time * 100;
-        for (int i = 0; i < zombieCount; i++)
-            zombies[i].x -= parallaxValue;
-        for (int i = 0; i < bulletCount; i++)
-            bullets[i].x -= parallaxValue;
-        for (int i = 0; i < platformsInScreen; i++)
-            platforms[i].x -= parallaxValue;
     }
     else if (player_X < (float)WINDOW_WIDTH * (leftCam/5)){
-        background_img_src_rect.x -= 50 * delta_time;
-        if (background_img_src_rect.x <= 0)
-            background_img_src_rect.x = background_img_src_rect.w;
         player_X = (leftCam/5) * (float)WINDOW_WIDTH;
         distanceTravelledByPlayerFromSpawn -= delta_time * 100;
-        for (int i = 0; i < zombieCount; i++)
-            zombies[i].x += parallaxValue;
-        for (int i = 0; i < bulletCount; i++)
-            bullets[i].x += parallaxValue;
-        for (int i = 0; i < platformsInScreen; i++)
-            platforms[i].x += parallaxValue;
     }
+
+    // UPDATED: Calculate background scroll based on player movement
+    float background_scroll = player_movement * BACKGROUND_SCROLL_FACTOR;
+
+    // UPDATED: Update background position using background_scroll
+    background_img_src_rect.x += background_scroll;
+
+    // UPDATED: Wrapping logic to prevent screen tearing
+    if (background_img_src_rect.x >= background_img_src_rect.w)
+        background_img_src_rect.x = 0;
+    else if (background_img_src_rect.x <= -background_img_src_rect.w)
+        background_img_src_rect.x = 0;
+
+    // UPDATED: Use player_movement for parallax
+    for (int i = 0; i < zombieCount; i++)
+        zombies[i].x -= player_movement;
+    for (int i = 0; i < bulletCount; i++)
+        bullets[i].x -= player_movement;
+    for (int i = 0; i < platformsInScreen; i++)
+        platforms[i].x -= player_movement;
 
     // Healing Ability
     playerHealth += delta_time;


### PR DESCRIPTION
**Update Update function to fix Inconsistent Background Scrolling Speed**

This pull request addresses the issue of inconsistent background scrolling speed. The original code used different multipliers for left and right scrolling, resulting in uneven movement.  This change calculates the background scroll based on the player's movement, ensuring consistent and smooth parallax.

**Changes made:**
- Introduced `player_movement` to track the player's displacement in each frame.
- Calculated `background_scroll` based on `player_movement` and the scroll factor.
- Updated `background_img_src_rect.x` using `background_scroll` for consistent movement.
- Used `player_movement` for parallax calculations of other game elements (zombies, bullets, platforms).

How to test:
1.  Run the game.
2.  Move the player left and right.
3.  Observe that the background now scrolls smoothly and consistently in both directions.